### PR TITLE
edit package swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .target(
             name: "AdvancedPageControl",
             dependencies: [],
-            path: "AdvancedPageControl"),
+            path: "AdvancedPageControl/Classes"),
         .testTarget(
             name: "AdvancedPageControlTests",
             dependencies: ["AdvancedPageControl"]),


### PR DESCRIPTION
Hi team, i found out that the Package.swift path is wrong, so if we try to add package by SPM, we will just get the struct AdvancedPageControl. 
I just edit Package.swift and everything work alright.
Hope this help.