### PR TITLE
Fix #19: Make drawer properties public + comprehensive test suite

### DIFF
--- a/AdvancedPageControl/Classes/Drawers/ColorBlendDrawer.swift
+++ b/AdvancedPageControl/Classes/Drawers/ColorBlendDrawer.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 public class ColorBlendDrawer: AdvancedPageControlDrawerParentWithIndicator, AdvancedPageControlDraw {
-    var scaleFactor: CGFloat = 8
+    public var scaleFactor: CGFloat = 8
     
     public func draw(_ rect: CGRect) {
         drawIndicators(rect)

--- a/AdvancedPageControl/Classes/Drawers/DrawerProtocol.swift
+++ b/AdvancedPageControl/Classes/Drawers/DrawerProtocol.swift
@@ -17,9 +17,9 @@ public protocol AdvancedPageControlDraw {
 }
 
 public class AdvancedPageControlDrawerParentWithIndicator: AdvancedPageControlDrawerParent {
-    var indicatorBorderColor: UIColor
-    var indicatorBorderWidth: CGFloat
-    var indicatorColor: UIColor
+    public var indicatorBorderColor: UIColor
+    public var indicatorBorderWidth: CGFloat
+    public var indicatorColor: UIColor
     public init(numberOfPages: Int? = 5,
                 height: CGFloat? = 16,
                 width: CGFloat? = 16,
@@ -55,13 +55,13 @@ public class AdvancedPageControlDrawerParent {
     public var size: CGFloat
     public var currentItem: CGFloat
     public var items = [Int]()
-    var width: CGFloat
-    var space: CGFloat
-    var radius: CGFloat
-    var dotsColor: UIColor
-    var isBordered: Bool
-    var borderColor: UIColor
-    var borderWidth: CGFloat
+    public var width: CGFloat
+    public var space: CGFloat
+    public var radius: CGFloat
+    public var dotsColor: UIColor
+    public var isBordered: Bool
+    public var borderColor: UIColor
+    public var borderWidth: CGFloat
 
     public init(numberOfPages: Int? = 5,
                 height: CGFloat? = 16,

--- a/AdvancedPageControl/Classes/Drawers/DropDrawer.swift
+++ b/AdvancedPageControl/Classes/Drawers/DropDrawer.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 public class DropDrawer: AdvancedPageControlDrawerParentWithIndicator, AdvancedPageControlDraw {
-    var dropRatio: CGFloat = -10
+    public var dropRatio: CGFloat = -10
 
     public func draw(_ rect: CGRect) {
         drawIndicators(rect)

--- a/AdvancedPageControl/Classes/Drawers/JumpDrawer.swift
+++ b/AdvancedPageControl/Classes/Drawers/JumpDrawer.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 public class JumpDrawer: AdvancedPageControlDrawerParentWithIndicator, AdvancedPageControlDraw {
-    var jumpRatio: CGFloat = 20
+    public var jumpRatio: CGFloat = 20
 
     public func draw(_ rect: CGRect) {
         drawIndicators(rect)

--- a/AdvancedPageControl/Classes/Drawers/ScaleDrawer.swift
+++ b/AdvancedPageControl/Classes/Drawers/ScaleDrawer.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 public class ScaleDrawer: AdvancedPageControlDrawerParentWithIndicator, AdvancedPageControlDraw {
-    var scaleFactor: CGFloat = 8
+    public var scaleFactor: CGFloat = 8
 
     public func draw(_ rect: CGRect) {
         drawIndicators(rect)

--- a/Sources/AdvancedPageControl/AdvancedPageControl.swift
+++ b/Sources/AdvancedPageControl/AdvancedPageControl.swift
@@ -1,3 +1,0 @@
-struct AdvancedPageControl {
-    var text = "Hello, World!"
-}

--- a/Tests/AdvancedPageControlTests/AdvancedPageControlTests.swift
+++ b/Tests/AdvancedPageControlTests/AdvancedPageControlTests.swift
@@ -1,15 +1,166 @@
 import XCTest
 @testable import AdvancedPageControl
 
-final class AdvancedPageControlTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(AdvancedPageControl().text, "Hello, World!")
+final class DrawerParentTests: XCTestCase {
+
+    // MARK: - Default Initialization
+
+    func testDefaultInitValues() {
+        let parent = AdvancedPageControlDrawerParent()
+        XCTAssertEqual(parent.numberOfPages, 5)
+        XCTAssertEqual(parent.size, 16)
+        XCTAssertEqual(parent.width, 16)
+        XCTAssertEqual(parent.space, 16)
+        XCTAssertEqual(parent.radius, 16)
+        XCTAssertEqual(parent.currentItem, 0)
+        XCTAssertEqual(parent.dotsColor, UIColor.lightGray)
+        XCTAssertEqual(parent.isBordered, false)
+        XCTAssertEqual(parent.borderColor, UIColor.white)
+        XCTAssertEqual(parent.borderWidth, 1)
+    }
+
+    // MARK: - Custom Initialization
+
+    func testCustomInitValues() {
+        let parent = AdvancedPageControlDrawerParent(
+            numberOfPages: 10,
+            height: 20,
+            width: 30,
+            space: 8,
+            raduis: 4,
+            currentItem: 3,
+            dotsColor: .red,
+            isBordered: true,
+            borderColor: .blue,
+            borderWidth: 2
+        )
+        XCTAssertEqual(parent.numberOfPages, 10)
+        XCTAssertEqual(parent.size, 20)
+        XCTAssertEqual(parent.width, 30)
+        XCTAssertEqual(parent.space, 8)
+        XCTAssertEqual(parent.radius, 4)
+        XCTAssertEqual(parent.currentItem, 3)
+        XCTAssertEqual(parent.dotsColor, UIColor.red)
+        XCTAssertEqual(parent.isBordered, true)
+        XCTAssertEqual(parent.borderColor, UIColor.blue)
+        XCTAssertEqual(parent.borderWidth, 2)
+    }
+
+    // MARK: - Property Mutation
+
+    func testPropertiesAreMutableAfterInit() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.width = 24
+        parent.space = 12
+        parent.radius = 6
+        parent.numberOfPages = 8
+        parent.size = 32
+        parent.currentItem = 2.5
+        parent.dotsColor = .green
+        parent.isBordered = true
+        parent.borderColor = .black
+        parent.borderWidth = 3
+
+        XCTAssertEqual(parent.width, 24)
+        XCTAssertEqual(parent.space, 12)
+        XCTAssertEqual(parent.radius, 6)
+        XCTAssertEqual(parent.numberOfPages, 8)
+        XCTAssertEqual(parent.size, 32)
+        XCTAssertEqual(parent.currentItem, 2.5)
+        XCTAssertEqual(parent.dotsColor, UIColor.green)
+        XCTAssertEqual(parent.isBordered, true)
+        XCTAssertEqual(parent.borderColor, UIColor.black)
+        XCTAssertEqual(parent.borderWidth, 3)
+    }
+
+    // MARK: - getScaleFactor
+
+    func testGetScaleFactorAtIntegerPosition() {
+        let parent = AdvancedPageControlDrawerParent()
+        let scale = parent.getScaleFactor(currentItem: 2.0, ratio: 10.0)
+        XCTAssertEqual(scale, 0.0, accuracy: 0.001)
+    }
+
+    func testGetScaleFactorAtHalfPosition() {
+        let parent = AdvancedPageControlDrawerParent()
+        let scale = parent.getScaleFactor(currentItem: 2.5, ratio: 10.0)
+        XCTAssertEqual(scale, 5.0, accuracy: 0.001)
+    }
+
+    func testGetScaleFactorAtQuarterPosition() {
+        let parent = AdvancedPageControlDrawerParent()
+        let scale = parent.getScaleFactor(currentItem: 2.25, ratio: 10.0)
+        XCTAssertEqual(scale, 2.5, accuracy: 0.001)
+    }
+
+    func testGetScaleFactorAtThreeQuarterPosition() {
+        let parent = AdvancedPageControlDrawerParent()
+        let scale = parent.getScaleFactor(currentItem: 2.75, ratio: 10.0)
+        XCTAssertEqual(scale, 2.5, accuracy: 0.001)
+    }
+
+    func testGetScaleFactorSymmetry() {
+        let parent = AdvancedPageControlDrawerParent()
+        let scale1 = parent.getScaleFactor(currentItem: 1.25, ratio: 20.0)
+        let scale2 = parent.getScaleFactor(currentItem: 1.75, ratio: 20.0)
+        XCTAssertEqual(scale1, scale2, accuracy: 0.001)
+    }
+
+    // MARK: - getCenteredYPosition
+
+    func testCenteredYPositionCentersDotVertically() {
+        let parent = AdvancedPageControlDrawerParent(height: 10)
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let y = parent.getCenteredYPosition(rect, dotSize: 10)
+        XCTAssertEqual(y, 15.0, accuracy: 0.001)
+    }
+
+    func testCenteredYPositionWithLargeDot() {
+        let parent = AdvancedPageControlDrawerParent(height: 40)
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let y = parent.getCenteredYPosition(rect, dotSize: 40)
+        XCTAssertEqual(y, 0.0, accuracy: 0.001)
+    }
+
+    // MARK: - getCenteredXPosition
+
+    func testCenteredXPositionFirstDot() {
+        let parent = AdvancedPageControlDrawerParent(numberOfPages: 3, width: 10, space: 5)
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x = parent.getCenteredXPosition(rect, itemPos: 0, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x, 79.0, accuracy: 0.001)
+    }
+
+    func testCenteredXPositionMiddleDot() {
+        let parent = AdvancedPageControlDrawerParent(numberOfPages: 3, width: 10, space: 5)
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x = parent.getCenteredXPosition(rect, itemPos: 1, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x, 94.0, accuracy: 0.001)
+    }
+
+    func testCenteredXPositionDotsAreEvenlySpaced() {
+        let parent = AdvancedPageControlDrawerParent(numberOfPages: 5, width: 10, space: 5)
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        let x0 = parent.getCenteredXPosition(rect, itemPos: 0, dotSize: 10, space: 5, numberOfPages: 5)
+        let x1 = parent.getCenteredXPosition(rect, itemPos: 1, dotSize: 10, space: 5, numberOfPages: 5)
+        let x2 = parent.getCenteredXPosition(rect, itemPos: 2, dotSize: 10, space: 5, numberOfPages: 5)
+        XCTAssertEqual(x1 - x0, 15.0, accuracy: 0.001)
+        XCTAssertEqual(x2 - x1, 15.0, accuracy: 0.001)
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testDefaultInitValues", testDefaultInitValues),
+        ("testCustomInitValues", testCustomInitValues),
+        ("testPropertiesAreMutableAfterInit", testPropertiesAreMutableAfterInit),
+        ("testGetScaleFactorAtIntegerPosition", testGetScaleFactorAtIntegerPosition),
+        ("testGetScaleFactorAtHalfPosition", testGetScaleFactorAtHalfPosition),
+        ("testGetScaleFactorAtQuarterPosition", testGetScaleFactorAtQuarterPosition),
+        ("testGetScaleFactorAtThreeQuarterPosition", testGetScaleFactorAtThreeQuarterPosition),
+        ("testGetScaleFactorSymmetry", testGetScaleFactorSymmetry),
+        ("testCenteredYPositionCentersDotVertically", testCenteredYPositionCentersDotVertically),
+        ("testCenteredYPositionWithLargeDot", testCenteredYPositionWithLargeDot),
+        ("testCenteredXPositionFirstDot", testCenteredXPositionFirstDot),
+        ("testCenteredXPositionMiddleDot", testCenteredXPositionMiddleDot),
+        ("testCenteredXPositionDotsAreEvenlySpaced", testCenteredXPositionDotsAreEvenlySpaced),
     ]
 }

--- a/Tests/AdvancedPageControlTests/AdvancedPageControlViewTests.swift
+++ b/Tests/AdvancedPageControlTests/AdvancedPageControlViewTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class AdvancedPageControlViewTests: XCTestCase {
+
+    // MARK: - Initialization
+
+    func testDefaultInit() {
+        let view = AdvancedPageControlView(frame: CGRect(x: 0, y: 0, width: 200, height: 40))
+        XCTAssertEqual(view.backgroundColor, UIColor.clear)
+    }
+
+    func testDefaultDrawerIsInfiniteScrolling() {
+        let view = AdvancedPageControlView(frame: .zero)
+        XCTAssertTrue(view.drawer is InfiniteScrollingDrawer)
+    }
+
+    // MARK: - numberOfPages
+
+    func testNumberOfPagesSyncsWithDrawer() {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.numberOfPages = 10
+        XCTAssertEqual(view.numberOfPages, 10)
+        XCTAssertEqual(view.drawer.numberOfPages, 10)
+    }
+
+    func testNumberOfPagesDefaultValue() {
+        let view = AdvancedPageControlView(frame: .zero)
+        XCTAssertEqual(view.numberOfPages, 5)
+    }
+
+    // MARK: - setPageOffset
+
+    func testSetPageOffsetUpdatesDrawerCurrentItem() {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.setPageOffset(3.5)
+        XCTAssertEqual(view.drawer.currentItem, 3.5)
+    }
+
+    func testSetPageOffsetToZero() {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.setPageOffset(2.0)
+        view.setPageOffset(0.0)
+        XCTAssertEqual(view.drawer.currentItem, 0.0)
+    }
+
+    // MARK: - Custom Drawer Assignment
+
+    func testAssignCustomDrawer() {
+        let view = AdvancedPageControlView(frame: .zero)
+        let wormDrawer = WormDrawer(numberOfPages: 8)
+        view.drawer = wormDrawer
+        XCTAssertEqual(view.numberOfPages, 8)
+        XCTAssertTrue(view.drawer is WormDrawer)
+    }
+
+    func testAssignExtendedDotDrawerWithCustomWidthRadius() {
+        let view = AdvancedPageControlView(frame: .zero)
+        let drawer = ExtendedDotDrawer(width: 24, raduis: 12)
+        view.drawer = drawer
+        let assignedDrawer = view.drawer as! ExtendedDotDrawer
+        XCTAssertEqual(assignedDrawer.width, 24)
+        XCTAssertEqual(assignedDrawer.radius, 12)
+    }
+
+    // MARK: - intrinsicContentSize
+
+    func testIntrinsicContentSizeUsesDrawerSize() {
+        let view = AdvancedPageControlView(frame: .zero)
+        let intrinsic = view.intrinsicContentSize
+        XCTAssertEqual(intrinsic.width, 16)
+        XCTAssertEqual(intrinsic.height, 32)
+    }
+
+    // MARK: - Draw Delegation
+
+    func testDrawDelegatesToDrawer() {
+        let view = AdvancedPageControlView(frame: CGRect(x: 0, y: 0, width: 300, height: 40))
+        view.drawer = SlideDrawer(numberOfPages: 3)
+        view.setPageOffset(1.0)
+        view.draw(view.bounds)
+    }
+
+    static var allTests = [
+        ("testDefaultInit", testDefaultInit),
+        ("testDefaultDrawerIsInfiniteScrolling", testDefaultDrawerIsInfiniteScrolling),
+        ("testNumberOfPagesSyncsWithDrawer", testNumberOfPagesSyncsWithDrawer),
+        ("testNumberOfPagesDefaultValue", testNumberOfPagesDefaultValue),
+        ("testSetPageOffsetUpdatesDrawerCurrentItem", testSetPageOffsetUpdatesDrawerCurrentItem),
+        ("testSetPageOffsetToZero", testSetPageOffsetToZero),
+        ("testAssignCustomDrawer", testAssignCustomDrawer),
+        ("testAssignExtendedDotDrawerWithCustomWidthRadius", testAssignExtendedDotDrawerWithCustomWidthRadius),
+        ("testIntrinsicContentSizeUsesDrawerSize", testIntrinsicContentSizeUsesDrawerSize),
+        ("testDrawDelegatesToDrawer", testDrawDelegatesToDrawer),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/AllDrawersTests.swift
+++ b/Tests/AdvancedPageControlTests/AllDrawersTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class AllDrawersTests: XCTestCase {
+
+    // MARK: - Helper
+
+    private func allDrawers() -> [(String, AdvancedPageControlDraw)] {
+        return [
+            ("ColorBlendDrawer", ColorBlendDrawer()),
+            ("DropDrawer", DropDrawer()),
+            ("ExtendedDotDrawer", ExtendedDotDrawer()),
+            ("InfiniteDrawer", InfiniteDrawer()),
+            ("InfiniteScrollingDrawer", InfiniteScrollingDrawer()),
+            ("JumpDrawer", JumpDrawer()),
+            ("ScaleDrawer", ScaleDrawer()),
+            ("ScrollingDrawer", ScrollingDrawer()),
+            ("SlideDrawer", SlideDrawer()),
+            ("SwapDrawer", SwapDrawer()),
+            ("ThinWormDrawer", ThinWormDrawer()),
+            ("ThinWormHeadsDrawer", ThinWormHeadsDrawer()),
+            ("WormDrawer", WormDrawer()),
+        ]
+    }
+
+    // MARK: - Protocol Conformance
+
+    func testAllDrawersConformToProtocol() {
+        for (name, drawer) in allDrawers() {
+            XCTAssertNotNil(drawer.currentItem, "\(name) missing currentItem")
+            XCTAssertNotNil(drawer.size, "\(name) missing size")
+            XCTAssertNotNil(drawer.numberOfPages, "\(name) missing numberOfPages")
+        }
+    }
+
+    // MARK: - Default Values
+
+    func testAllDrawersHaveConsistentDefaults() {
+        for (name, drawer) in allDrawers() {
+            XCTAssertEqual(drawer.numberOfPages, 5, "\(name) default numberOfPages")
+            XCTAssertEqual(drawer.size, 16, "\(name) default size")
+            XCTAssertEqual(drawer.currentItem, 0, "\(name) default currentItem")
+        }
+    }
+
+    // MARK: - Custom Initialization
+
+    func testAllDrawersAcceptCustomValues() {
+        let drawers: [(String, AdvancedPageControlDraw)] = [
+            ("ColorBlendDrawer", ColorBlendDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("DropDrawer", DropDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("ExtendedDotDrawer", ExtendedDotDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("InfiniteDrawer", InfiniteDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("InfiniteScrollingDrawer", InfiniteScrollingDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("JumpDrawer", JumpDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("ScaleDrawer", ScaleDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("ScrollingDrawer", ScrollingDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("SlideDrawer", SlideDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("SwapDrawer", SwapDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("ThinWormDrawer", ThinWormDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("ThinWormHeadsDrawer", ThinWormHeadsDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+            ("WormDrawer", WormDrawer(numberOfPages: 10, height: 20, width: 30, space: 8, raduis: 4)),
+        ]
+        for (name, drawer) in drawers {
+            XCTAssertEqual(drawer.numberOfPages, 10, "\(name) custom numberOfPages")
+            XCTAssertEqual(drawer.size, 20, "\(name) custom height->size")
+        }
+    }
+
+    // MARK: - currentItem Mutation
+
+    func testAllDrawersAllowCurrentItemMutation() {
+        for (name, var drawer) in allDrawers() {
+            drawer.currentItem = 3.5
+            XCTAssertEqual(drawer.currentItem, 3.5, "\(name) currentItem mutation")
+        }
+    }
+
+    // MARK: - Draw Does Not Crash
+
+    func testAllDrawersDrawWithoutCrashing() {
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        for (name, drawer) in allDrawers() {
+            drawer.draw(rect)
+            XCTAssertTrue(true, "\(name) draw did not crash")
+        }
+    }
+
+    func testAllDrawersDrawAtMidTransition() {
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        for (name, var drawer) in allDrawers() {
+            drawer.currentItem = 2.5
+            drawer.draw(rect)
+            XCTAssertTrue(true, "\(name) draw at mid-transition did not crash")
+        }
+    }
+
+    func testAllDrawersDrawAtLastPage() {
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        for (name, var drawer) in allDrawers() {
+            drawer.currentItem = CGFloat(drawer.numberOfPages - 1)
+            drawer.draw(rect)
+            XCTAssertTrue(true, "\(name) draw at last page did not crash")
+        }
+    }
+
+    // MARK: - Drawer-Specific Properties
+
+    func testColorBlendDrawerScaleFactor() {
+        let drawer = ColorBlendDrawer()
+        XCTAssertEqual(drawer.scaleFactor, 8)
+        drawer.scaleFactor = 12
+        XCTAssertEqual(drawer.scaleFactor, 12)
+    }
+
+    func testScaleDrawerScaleFactor() {
+        let drawer = ScaleDrawer()
+        XCTAssertEqual(drawer.scaleFactor, 8)
+        drawer.scaleFactor = 4
+        XCTAssertEqual(drawer.scaleFactor, 4)
+    }
+
+    func testDropDrawerDropRatio() {
+        let drawer = DropDrawer()
+        XCTAssertEqual(drawer.dropRatio, -10)
+        drawer.dropRatio = -20
+        XCTAssertEqual(drawer.dropRatio, -20)
+    }
+
+    func testJumpDrawerJumpRatio() {
+        let drawer = JumpDrawer()
+        XCTAssertEqual(drawer.jumpRatio, 20)
+        drawer.jumpRatio = 30
+        XCTAssertEqual(drawer.jumpRatio, 30)
+    }
+
+    static var allTests = [
+        ("testAllDrawersConformToProtocol", testAllDrawersConformToProtocol),
+        ("testAllDrawersHaveConsistentDefaults", testAllDrawersHaveConsistentDefaults),
+        ("testAllDrawersAcceptCustomValues", testAllDrawersAcceptCustomValues),
+        ("testAllDrawersAllowCurrentItemMutation", testAllDrawersAllowCurrentItemMutation),
+        ("testAllDrawersDrawWithoutCrashing", testAllDrawersDrawWithoutCrashing),
+        ("testAllDrawersDrawAtMidTransition", testAllDrawersDrawAtMidTransition),
+        ("testAllDrawersDrawAtLastPage", testAllDrawersDrawAtLastPage),
+        ("testColorBlendDrawerScaleFactor", testColorBlendDrawerScaleFactor),
+        ("testScaleDrawerScaleFactor", testScaleDrawerScaleFactor),
+        ("testDropDrawerDropRatio", testDropDrawerDropRatio),
+        ("testJumpDrawerJumpRatio", testJumpDrawerJumpRatio),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/ColorUtilsTests.swift
+++ b/Tests/AdvancedPageControlTests/ColorUtilsTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class ColorUtilsTests: XCTestCase {
+
+    private func assertColorComponents(
+        _ color: UIColor,
+        red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat,
+        accuracy: CGFloat = 0.01,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+        XCTAssertEqual(r, red, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(g, green, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(b, blue, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(a, alpha, accuracy: accuracy, file: file, line: line)
+    }
+
+    // MARK: - addColor
+
+    func testAddBlackAndWhite() {
+        let result = addColor(.black, with: .white)
+        assertColorComponents(result, red: 1, green: 1, blue: 1, alpha: 1)
+    }
+
+    func testAddColorClampedToOne() {
+        let result = addColor(.white, with: .white)
+        assertColorComponents(result, red: 1, green: 1, blue: 1, alpha: 1)
+    }
+
+    func testAddRedAndBlue() {
+        let result = addColor(.red, with: .blue)
+        assertColorComponents(result, red: 1, green: 0, blue: 1, alpha: 1)
+    }
+
+    func testAddBlackAndBlack() {
+        let result = addColor(.black, with: .black)
+        assertColorComponents(result, red: 0, green: 0, blue: 0, alpha: 1)
+    }
+
+    // MARK: - multiplyColor
+
+    func testMultiplyByZero() {
+        let result = multiplyColor(.white, by: 0)
+        assertColorComponents(result, red: 0, green: 0, blue: 0, alpha: 1)
+    }
+
+    func testMultiplyByOne() {
+        let result = multiplyColor(.red, by: 1.0)
+        assertColorComponents(result, red: 1, green: 0, blue: 0, alpha: 1)
+    }
+
+    func testMultiplyByHalf() {
+        let result = multiplyColor(.white, by: 0.5)
+        assertColorComponents(result, red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+    }
+
+    // MARK: - Operator Overloads
+
+    func testPlusOperator() {
+        let result = UIColor.red + UIColor.green
+        assertColorComponents(result, red: 1, green: 1, blue: 0, alpha: 1)
+    }
+
+    func testMultiplyOperator() {
+        let result = UIColor.white * 0.5
+        assertColorComponents(result, red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+    }
+
+    func testMultiplyOperatorByZero() {
+        let result = UIColor.red * 0.0
+        assertColorComponents(result, red: 0, green: 0, blue: 0, alpha: 1)
+    }
+
+    // MARK: - Color Blending (as used by drawers)
+
+    func testBlendingInterpolation() {
+        let progress = 0.5
+        let result = (UIColor.red * progress) + (UIColor.blue * (1 - progress))
+        assertColorComponents(result, red: 0.5, green: 0, blue: 0.5, alpha: 1)
+    }
+
+    func testBlendingAtZeroProgress() {
+        let result = (UIColor.red * 0.0) + (UIColor.blue * 1.0)
+        assertColorComponents(result, red: 0, green: 0, blue: 1, alpha: 1)
+    }
+
+    func testBlendingAtFullProgress() {
+        let result = (UIColor.red * 1.0) + (UIColor.blue * 0.0)
+        assertColorComponents(result, red: 1, green: 0, blue: 0, alpha: 1)
+    }
+
+    static var allTests = [
+        ("testAddBlackAndWhite", testAddBlackAndWhite),
+        ("testAddColorClampedToOne", testAddColorClampedToOne),
+        ("testAddRedAndBlue", testAddRedAndBlue),
+        ("testAddBlackAndBlack", testAddBlackAndBlack),
+        ("testMultiplyByZero", testMultiplyByZero),
+        ("testMultiplyByOne", testMultiplyByOne),
+        ("testMultiplyByHalf", testMultiplyByHalf),
+        ("testPlusOperator", testPlusOperator),
+        ("testMultiplyOperator", testMultiplyOperator),
+        ("testMultiplyOperatorByZero", testMultiplyOperatorByZero),
+        ("testBlendingInterpolation", testBlendingInterpolation),
+        ("testBlendingAtZeroProgress", testBlendingAtZeroProgress),
+        ("testBlendingAtFullProgress", testBlendingAtFullProgress),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/DrawerParentWithIndicatorTests.swift
+++ b/Tests/AdvancedPageControlTests/DrawerParentWithIndicatorTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class DrawerParentWithIndicatorTests: XCTestCase {
+
+    // MARK: - Default Initialization
+
+    func testDefaultInitValues() {
+        let drawer = AdvancedPageControlDrawerParentWithIndicator()
+        XCTAssertEqual(drawer.numberOfPages, 5)
+        XCTAssertEqual(drawer.size, 16)
+        XCTAssertEqual(drawer.width, 16)
+        XCTAssertEqual(drawer.space, 16)
+        XCTAssertEqual(drawer.radius, 8)
+        XCTAssertEqual(drawer.currentItem, 0)
+        XCTAssertEqual(drawer.dotsColor, UIColor.lightGray)
+        XCTAssertEqual(drawer.indicatorColor, UIColor.white)
+        XCTAssertEqual(drawer.indicatorBorderColor, UIColor.white)
+        XCTAssertEqual(drawer.indicatorBorderWidth, 2)
+    }
+
+    // MARK: - Custom Initialization
+
+    func testCustomInitValues() {
+        let drawer = AdvancedPageControlDrawerParentWithIndicator(
+            numberOfPages: 7,
+            height: 12,
+            width: 24,
+            space: 6,
+            raduis: 3,
+            currentItem: 2,
+            indicatorColor: .red,
+            dotsColor: .blue,
+            isBordered: true,
+            borderColor: .green,
+            borderWidth: 2,
+            indicatorBorderColor: .yellow,
+            indicatorBorderWidth: 4
+        )
+        XCTAssertEqual(drawer.numberOfPages, 7)
+        XCTAssertEqual(drawer.size, 12)
+        XCTAssertEqual(drawer.width, 24)
+        XCTAssertEqual(drawer.space, 6)
+        XCTAssertEqual(drawer.radius, 3)
+        XCTAssertEqual(drawer.currentItem, 2)
+        XCTAssertEqual(drawer.indicatorColor, UIColor.red)
+        XCTAssertEqual(drawer.dotsColor, UIColor.blue)
+        XCTAssertEqual(drawer.isBordered, true)
+        XCTAssertEqual(drawer.borderColor, UIColor.green)
+        XCTAssertEqual(drawer.borderWidth, 2)
+        XCTAssertEqual(drawer.indicatorBorderColor, UIColor.yellow)
+        XCTAssertEqual(drawer.indicatorBorderWidth, 4)
+    }
+
+    // MARK: - Property Mutation
+
+    func testIndicatorPropertiesAreMutableAfterInit() {
+        let drawer = AdvancedPageControlDrawerParentWithIndicator()
+        drawer.indicatorColor = .orange
+        drawer.indicatorBorderColor = .purple
+        drawer.indicatorBorderWidth = 5
+
+        XCTAssertEqual(drawer.indicatorColor, UIColor.orange)
+        XCTAssertEqual(drawer.indicatorBorderColor, UIColor.purple)
+        XCTAssertEqual(drawer.indicatorBorderWidth, 5)
+    }
+
+    static var allTests = [
+        ("testDefaultInitValues", testDefaultInitValues),
+        ("testCustomInitValues", testCustomInitValues),
+        ("testIndicatorPropertiesAreMutableAfterInit", testIndicatorPropertiesAreMutableAfterInit),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/ExtendedDotDrawerTests.swift
+++ b/Tests/AdvancedPageControlTests/ExtendedDotDrawerTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class ExtendedDotDrawerTests: XCTestCase {
+
+    // MARK: - Issue #19: Width and Radius Must Be Settable
+
+    func testWidthIsSettableAfterInit() {
+        let drawer = ExtendedDotDrawer()
+        XCTAssertEqual(drawer.width, 16)
+        drawer.width = 24
+        XCTAssertEqual(drawer.width, 24)
+    }
+
+    func testRadiusIsSettableAfterInit() {
+        let drawer = ExtendedDotDrawer()
+        XCTAssertEqual(drawer.radius, 8)
+        drawer.radius = 12
+        XCTAssertEqual(drawer.radius, 12)
+    }
+
+    func testCustomWidthViaInit() {
+        let drawer = ExtendedDotDrawer(width: 32)
+        XCTAssertEqual(drawer.width, 32)
+    }
+
+    func testCustomRadiusViaInit() {
+        let drawer = ExtendedDotDrawer(raduis: 4)
+        XCTAssertEqual(drawer.radius, 4)
+    }
+
+    func testCustomWidthAndRadiusTogether() {
+        let drawer = ExtendedDotDrawer(width: 20, raduis: 10)
+        XCTAssertEqual(drawer.width, 20)
+        XCTAssertEqual(drawer.radius, 10)
+    }
+
+    // MARK: - Draw With Custom Values Does Not Crash
+
+    func testDrawWithCustomWidthAndRadius() {
+        let drawer = ExtendedDotDrawer(
+            numberOfPages: 5, height: 12, width: 24, space: 8, raduis: 6,
+            indicatorColor: .red, dotsColor: .gray
+        )
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        drawer.draw(rect)
+    }
+
+    func testDrawAfterMutatingWidthAndRadius() {
+        let drawer = ExtendedDotDrawer()
+        drawer.width = 30
+        drawer.radius = 15
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        drawer.draw(rect)
+        XCTAssertEqual(drawer.width, 30)
+        XCTAssertEqual(drawer.radius, 15)
+    }
+
+    // MARK: - Page Transitions
+
+    func testDrawDuringPageTransition() {
+        let drawer = ExtendedDotDrawer(numberOfPages: 5, width: 20, raduis: 10)
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        for progress in stride(from: 0.0, through: 1.0, by: 0.1) {
+            drawer.currentItem = CGFloat(progress)
+            drawer.draw(rect)
+        }
+    }
+
+    func testDrawAtBoundaryPages() {
+        let drawer = ExtendedDotDrawer(numberOfPages: 3, width: 20, raduis: 10)
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        drawer.currentItem = 0
+        drawer.draw(rect)
+        drawer.currentItem = 2
+        drawer.draw(rect)
+    }
+
+    // MARK: - Space Property
+
+    func testSpaceIsSettableAfterInit() {
+        let drawer = ExtendedDotDrawer()
+        XCTAssertEqual(drawer.space, 16)
+        drawer.space = 10
+        XCTAssertEqual(drawer.space, 10)
+    }
+
+    static var allTests = [
+        ("testWidthIsSettableAfterInit", testWidthIsSettableAfterInit),
+        ("testRadiusIsSettableAfterInit", testRadiusIsSettableAfterInit),
+        ("testCustomWidthViaInit", testCustomWidthViaInit),
+        ("testCustomRadiusViaInit", testCustomRadiusViaInit),
+        ("testCustomWidthAndRadiusTogether", testCustomWidthAndRadiusTogether),
+        ("testDrawWithCustomWidthAndRadius", testDrawWithCustomWidthAndRadius),
+        ("testDrawAfterMutatingWidthAndRadius", testDrawAfterMutatingWidthAndRadius),
+        ("testDrawDuringPageTransition", testDrawDuringPageTransition),
+        ("testDrawAtBoundaryPages", testDrawAtBoundaryPages),
+        ("testSpaceIsSettableAfterInit", testSpaceIsSettableAfterInit),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/XCTestManifests.swift
+++ b/Tests/AdvancedPageControlTests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(AdvancedPageControlTests.allTests),
+        testCase(DrawerParentTests.allTests),
     ]
 }
 #endif

--- a/Tests/AdvancedPageControlTests/XCTestManifests.swift
+++ b/Tests/AdvancedPageControlTests/XCTestManifests.swift
@@ -4,6 +4,11 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(DrawerParentTests.allTests),
+        testCase(DrawerParentWithIndicatorTests.allTests),
+        testCase(ColorUtilsTests.allTests),
+        testCase(AllDrawersTests.allTests),
+        testCase(ExtendedDotDrawerTests.allTests),
+        testCase(AdvancedPageControlViewTests.allTests),
     ]
 }
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,6 @@
 import XCTest
+@testable import AdvancedPageControlTests
 
-import AdvancedPageControlTests
-
-var tests = [XCTestCaseEntry]()
-tests += AdvancedPageControlTests.allTests()
-XCTMain(tests)
+XCTMain([
+    testCase(DrawerParentTests.allTests),
+])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,4 +3,9 @@ import XCTest
 
 XCTMain([
     testCase(DrawerParentTests.allTests),
+    testCase(DrawerParentWithIndicatorTests.allTests),
+    testCase(ColorUtilsTests.allTests),
+    testCase(AllDrawersTests.allTests),
+    testCase(ExtendedDotDrawerTests.allTests),
+    testCase(AdvancedPageControlViewTests.allTests),
 ])


### PR DESCRIPTION
## Summary
- **Fixes #19** — `ExtendedDotDrawer` (and all drawers) now expose `width`, `space`, `radius`, colors, and border properties as `public` so consumers can read and modify them after initialization
- Removed dead placeholder stub (`Sources/AdvancedPageControl/AdvancedPageControl.swift`)
- Added comprehensive test suite with **60 unit tests** covering all components

## Test Coverage
| Test Class | Tests | What It Covers |
|---|---|---|
| DrawerParentTests | 13 | Default/custom init, property mutation, `getScaleFactor` math, centering geometry |
| DrawerParentWithIndicatorTests | 3 | Default/custom init, indicator property mutation |
| ColorUtilsTests | 13 | `addColor`, `multiplyColor`, operators, color blending |
| AllDrawersTests | 11 | All 13 drawers: protocol conformance, defaults, draw-crash safety |
| ExtendedDotDrawerTests | 10 | Issue #19 verification: width/radius settable via init and post-init |
| AdvancedPageControlViewTests | 10 | View init, drawer sync, page offset, intrinsic size, draw delegation |

## Test plan
- [x] All 60 tests pass on iOS Simulator (iPhone 16, iOS 18.3.1)
- [x] Build succeeds with no warnings
- [x] Properties verified settable both via init params and post-init mutation