### PR TITLE
Feat #15: Add left/center/right alignment to AdvancedPageControlView

### DIFF
--- a/AdvancedPageControl/Classes/AdvancedPageControlView.swift
+++ b/AdvancedPageControl/Classes/AdvancedPageControlView.swift
@@ -22,7 +22,19 @@ public class AdvancedPageControlView: UIView {
         drawer.numberOfPages = val
     }}
 
-    public var drawer: AdvancedPageControlDraw = InfiniteScrollingDrawer()
+    public var drawer: AdvancedPageControlDraw = InfiniteScrollingDrawer() {
+        didSet {
+            (drawer as? AdvancedPageControlDrawerParent)?.alignment = alignment
+            setNeedsDisplay()
+        }
+    }
+
+    public var alignment: PageControlAlignment = .center {
+        didSet {
+            (drawer as? AdvancedPageControlDrawerParent)?.alignment = alignment
+            setNeedsDisplay()
+        }
+    }
     
     init() {
         super.init(frame: .zero)

--- a/AdvancedPageControl/Classes/Drawers/DrawerProtocol.swift
+++ b/AdvancedPageControl/Classes/Drawers/DrawerProtocol.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 import UIKit
+
+public enum PageControlAlignment {
+    case left, center, right
+}
+
 public protocol AdvancedPageControlDraw {
     var currentItem: CGFloat { get set }
     var size: CGFloat { get set }
@@ -62,6 +67,7 @@ public class AdvancedPageControlDrawerParent {
     public var isBordered: Bool
     public var borderColor: UIColor
     public var borderWidth: CGFloat
+    public var alignment: PageControlAlignment = .center
 
     public init(numberOfPages: Int? = 5,
                 height: CGFloat? = 16,
@@ -93,10 +99,18 @@ public class AdvancedPageControlDrawerParent {
     }
 
     func getCenteredXPosition(_ rect: CGRect, itemPos: CGFloat, dotSize: CGFloat, space: CGFloat, numberOfPages: Int) -> CGFloat {
-        let individualDotPos = (itemPos * (dotSize + space))
-        let halfViewWidth = (rect.width / 2)
-        let halfAlldotsWidthWithSpaces = ((CGFloat(numberOfPages) * (dotSize + (space - 1))) / 2.0)
-        return individualDotPos - halfAlldotsWidthWithSpaces + halfViewWidth
+        let individualDotPos = itemPos * (dotSize + space)
+        switch alignment {
+        case .left:
+            return individualDotPos
+        case .right:
+            let totalDotsWidth = CGFloat(numberOfPages) * dotSize + CGFloat(numberOfPages - 1) * space
+            return rect.width + individualDotPos - totalDotsWidth
+        case .center:
+            let halfViewWidth = rect.width / 2
+            let halfAlldotsWidthWithSpaces = (CGFloat(numberOfPages) * (dotSize + (space - 1))) / 2.0
+            return individualDotPos - halfAlldotsWidthWithSpaces + halfViewWidth
+        }
     }
 
     func getCenteredYPosition(_ rect: CGRect, dotSize: CGFloat) -> CGFloat {

--- a/Tests/AdvancedPageControlTests/AdvancedPageControlViewAlignmentTests.swift
+++ b/Tests/AdvancedPageControlTests/AdvancedPageControlViewAlignmentTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class AdvancedPageControlViewAlignmentTests: XCTestCase {
+
+    func testDefaultAlignmentIsCenter() {
+        let view = AdvancedPageControlView(frame: .zero)
+        XCTAssertEqual(view.alignment, .center)
+    }
+
+    func testSettingAlignmentSyncsToDrawer() throws {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.drawer = SlideDrawer()
+        view.alignment = .left
+        let drawer = try XCTUnwrap(view.drawer as? AdvancedPageControlDrawerParent)
+        XCTAssertEqual(drawer.alignment, .left)
+    }
+
+    func testSettingAlignmentToRightSyncsToDrawer() throws {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.drawer = WormDrawer()
+        view.alignment = .right
+        let drawer = try XCTUnwrap(view.drawer as? AdvancedPageControlDrawerParent)
+        XCTAssertEqual(drawer.alignment, .right)
+    }
+
+    func testSettingAlignmentToCenterSyncsToDrawer() throws {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.drawer = ExtendedDotDrawer()
+        view.alignment = .center
+        let drawer = try XCTUnwrap(view.drawer as? AdvancedPageControlDrawerParent)
+        XCTAssertEqual(drawer.alignment, .center)
+    }
+
+    func testNewDrawerInheritsCurrentAlignment() throws {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.alignment = .left
+        view.drawer = ScaleDrawer()
+        let drawer = try XCTUnwrap(view.drawer as? AdvancedPageControlDrawerParent)
+        XCTAssertEqual(drawer.alignment, .left)
+    }
+
+    func testNewDrawerInheritsRightAlignment() throws {
+        let view = AdvancedPageControlView(frame: .zero)
+        view.alignment = .right
+        view.drawer = JumpDrawer()
+        let drawer = try XCTUnwrap(view.drawer as? AdvancedPageControlDrawerParent)
+        XCTAssertEqual(drawer.alignment, .right)
+    }
+
+    func testDrawWithLeftAlignmentDoesNotCrash() {
+        let view = AdvancedPageControlView(frame: CGRect(x: 0, y: 0, width: 300, height: 40))
+        view.drawer = SlideDrawer(numberOfPages: 5)
+        view.alignment = .left
+        view.draw(view.bounds)
+    }
+
+    func testDrawWithRightAlignmentDoesNotCrash() {
+        let view = AdvancedPageControlView(frame: CGRect(x: 0, y: 0, width: 300, height: 40))
+        view.drawer = WormDrawer(numberOfPages: 5)
+        view.alignment = .right
+        view.draw(view.bounds)
+    }
+
+    func testAllDrawersDrawWithLeftAlignment() {
+        let drawers: [AdvancedPageControlDraw] = [
+            ColorBlendDrawer(), DropDrawer(), ExtendedDotDrawer(),
+            InfiniteDrawer(), InfiniteScrollingDrawer(), JumpDrawer(),
+            ScaleDrawer(), ScrollingDrawer(), SlideDrawer(),
+            SwapDrawer(), ThinWormDrawer(), ThinWormHeadsDrawer(), WormDrawer()
+        ]
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        for drawer in drawers {
+            let view = AdvancedPageControlView(frame: rect)
+            view.drawer = drawer
+            view.alignment = .left
+            view.draw(rect)
+        }
+    }
+
+    func testAllDrawersDrawWithRightAlignment() {
+        let drawers: [AdvancedPageControlDraw] = [
+            ColorBlendDrawer(), DropDrawer(), ExtendedDotDrawer(),
+            InfiniteDrawer(), InfiniteScrollingDrawer(), JumpDrawer(),
+            ScaleDrawer(), ScrollingDrawer(), SlideDrawer(),
+            SwapDrawer(), ThinWormDrawer(), ThinWormHeadsDrawer(), WormDrawer()
+        ]
+        let rect = CGRect(x: 0, y: 0, width: 300, height: 40)
+        for drawer in drawers {
+            let view = AdvancedPageControlView(frame: rect)
+            view.drawer = drawer
+            view.alignment = .right
+            view.draw(rect)
+        }
+    }
+
+    static var allTests = [
+        ("testDefaultAlignmentIsCenter", testDefaultAlignmentIsCenter),
+        ("testSettingAlignmentSyncsToDrawer", testSettingAlignmentSyncsToDrawer),
+        ("testSettingAlignmentToRightSyncsToDrawer", testSettingAlignmentToRightSyncsToDrawer),
+        ("testSettingAlignmentToCenterSyncsToDrawer", testSettingAlignmentToCenterSyncsToDrawer),
+        ("testNewDrawerInheritsCurrentAlignment", testNewDrawerInheritsCurrentAlignment),
+        ("testNewDrawerInheritsRightAlignment", testNewDrawerInheritsRightAlignment),
+        ("testDrawWithLeftAlignmentDoesNotCrash", testDrawWithLeftAlignmentDoesNotCrash),
+        ("testDrawWithRightAlignmentDoesNotCrash", testDrawWithRightAlignmentDoesNotCrash),
+        ("testAllDrawersDrawWithLeftAlignment", testAllDrawersDrawWithLeftAlignment),
+        ("testAllDrawersDrawWithRightAlignment", testAllDrawersDrawWithRightAlignment),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/DrawerParentAlignmentTests.swift
+++ b/Tests/AdvancedPageControlTests/DrawerParentAlignmentTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import AdvancedPageControl
+
+final class DrawerParentAlignmentTests: XCTestCase {
+
+    func testDefaultAlignmentIsCenter() {
+        let parent = AdvancedPageControlDrawerParent()
+        XCTAssertEqual(parent.alignment, .center)
+    }
+
+    func testLeftAlignmentFirstDotStartsAtZero() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.alignment = .left
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x = parent.getCenteredXPosition(rect, itemPos: 0, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x, 0, accuracy: 0.001)
+    }
+
+    func testLeftAlignmentDotsAreEvenlySpaced() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.alignment = .left
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x0 = parent.getCenteredXPosition(rect, itemPos: 0, dotSize: 10, space: 5, numberOfPages: 3)
+        let x1 = parent.getCenteredXPosition(rect, itemPos: 1, dotSize: 10, space: 5, numberOfPages: 3)
+        let x2 = parent.getCenteredXPosition(rect, itemPos: 2, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x1 - x0, 15, accuracy: 0.001)
+        XCTAssertEqual(x2 - x1, 15, accuracy: 0.001)
+    }
+
+    func testRightAlignmentLastDotEndsAtRectWidth() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.alignment = .right
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x = parent.getCenteredXPosition(rect, itemPos: 2, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x + 10, rect.width, accuracy: 0.001)
+    }
+
+    func testRightAlignmentDotsAreEvenlySpaced() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.alignment = .right
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x0 = parent.getCenteredXPosition(rect, itemPos: 0, dotSize: 10, space: 5, numberOfPages: 3)
+        let x1 = parent.getCenteredXPosition(rect, itemPos: 1, dotSize: 10, space: 5, numberOfPages: 3)
+        let x2 = parent.getCenteredXPosition(rect, itemPos: 2, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x1 - x0, 15, accuracy: 0.001)
+        XCTAssertEqual(x2 - x1, 15, accuracy: 0.001)
+    }
+
+    func testCenterAlignmentMatchesOriginalFormula() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.alignment = .center
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let x = parent.getCenteredXPosition(rect, itemPos: 0, dotSize: 10, space: 5, numberOfPages: 3)
+        XCTAssertEqual(x, 79, accuracy: 0.001)
+    }
+
+    func testAlignmentIsMutableAfterInit() {
+        let parent = AdvancedPageControlDrawerParent()
+        parent.alignment = .left
+        XCTAssertEqual(parent.alignment, .left)
+        parent.alignment = .right
+        XCTAssertEqual(parent.alignment, .right)
+        parent.alignment = .center
+        XCTAssertEqual(parent.alignment, .center)
+    }
+
+    static var allTests = [
+        ("testDefaultAlignmentIsCenter", testDefaultAlignmentIsCenter),
+        ("testLeftAlignmentFirstDotStartsAtZero", testLeftAlignmentFirstDotStartsAtZero),
+        ("testLeftAlignmentDotsAreEvenlySpaced", testLeftAlignmentDotsAreEvenlySpaced),
+        ("testRightAlignmentLastDotEndsAtRectWidth", testRightAlignmentLastDotEndsAtRectWidth),
+        ("testRightAlignmentDotsAreEvenlySpaced", testRightAlignmentDotsAreEvenlySpaced),
+        ("testCenterAlignmentMatchesOriginalFormula", testCenterAlignmentMatchesOriginalFormula),
+        ("testAlignmentIsMutableAfterInit", testAlignmentIsMutableAfterInit),
+    ]
+}

--- a/Tests/AdvancedPageControlTests/XCTestManifests.swift
+++ b/Tests/AdvancedPageControlTests/XCTestManifests.swift
@@ -9,6 +9,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(AllDrawersTests.allTests),
         testCase(ExtendedDotDrawerTests.allTests),
         testCase(AdvancedPageControlViewTests.allTests),
+        testCase(DrawerParentAlignmentTests.allTests),
     ]
 }
 #endif

--- a/Tests/AdvancedPageControlTests/XCTestManifests.swift
+++ b/Tests/AdvancedPageControlTests/XCTestManifests.swift
@@ -10,6 +10,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(ExtendedDotDrawerTests.allTests),
         testCase(AdvancedPageControlViewTests.allTests),
         testCase(DrawerParentAlignmentTests.allTests),
+        testCase(AdvancedPageControlViewAlignmentTests.allTests),
     ]
 }
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,12 +1,6 @@
 import XCTest
-@testable import AdvancedPageControlTests
+import AdvancedPageControlTests
 
-XCTMain([
-    testCase(DrawerParentTests.allTests),
-    testCase(DrawerParentWithIndicatorTests.allTests),
-    testCase(ColorUtilsTests.allTests),
-    testCase(AllDrawersTests.allTests),
-    testCase(ExtendedDotDrawerTests.allTests),
-    testCase(AdvancedPageControlViewTests.allTests),
-    testCase(DrawerParentAlignmentTests.allTests),
-])
+var tests = [XCTestCaseEntry]()
+tests += AdvancedPageControlTests.allTests()
+XCTMain(tests)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,4 +8,5 @@ XCTMain([
     testCase(AllDrawersTests.allTests),
     testCase(ExtendedDotDrawerTests.allTests),
     testCase(AdvancedPageControlViewTests.allTests),
+    testCase(DrawerParentAlignmentTests.allTests),
 ])

--- a/docs/superpowers/specs/2026-04-16-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-16-alignment-design.md
@@ -1,0 +1,93 @@
+# Alignment Support Design
+
+## Goal
+Add `.left`, `.center`, `.right` alignment to `AdvancedPageControlView` so consumers can pin the dot indicator to either edge of its container rather than always centering it.
+
+## Context
+Issue #15 — users want left/right alignment. A community workaround exists (override `getCenteredXPosition`) but requires subclassing. This adds it as a first-class property.
+
+---
+
+## New Type: PageControlAlignment
+
+Added to `AdvancedPageControl/Classes/Drawers/DrawerProtocol.swift`:
+
+```swift
+public enum PageControlAlignment {
+    case left, center, right
+}
+```
+
+---
+
+## AdvancedPageControlDrawerParent
+
+**New property** (internal — not exposed on the protocol):
+```swift
+var alignment: PageControlAlignment = .center
+```
+
+**Modified `getCenteredXPosition`** — branches on alignment:
+
+- `.center` — existing formula, unchanged:
+  ```swift
+  let individualDotPos = itemPos * (dotSize + space)
+  let halfViewWidth = rect.width / 2
+  let halfAllDotsWidth = (CGFloat(numberOfPages) * (dotSize + (space - 1))) / 2.0
+  return individualDotPos - halfAllDotsWidth + halfViewWidth
+  ```
+
+- `.left` — dots start at rect origin:
+  ```swift
+  return itemPos * (dotSize + space)
+  ```
+
+- `.right` — dots end at rect right edge:
+  ```swift
+  let individualDotPos = itemPos * (dotSize + space)
+  let totalDotsWidth = CGFloat(numberOfPages) * dotSize + CGFloat(numberOfPages - 1) * space
+  return rect.width + individualDotPos - totalDotsWidth
+  ```
+
+All 13 drawer subclasses inherit the change automatically with no modifications.
+
+---
+
+## AdvancedPageControlView
+
+**New public property:**
+```swift
+public var alignment: PageControlAlignment = .center {
+    didSet {
+        (drawer as? AdvancedPageControlDrawerParent)?.alignment = alignment
+        setNeedsDisplay()
+    }
+}
+```
+
+Syncs to the drawer whenever set. Calls `setNeedsDisplay()` so the change is immediately visible. Custom drawers that implement `AdvancedPageControlDraw` directly (not via `AdvancedPageControlDrawerParent`) are unaffected — they handle their own layout.
+
+Also syncs on drawer assignment — when the user sets a new drawer, the current alignment is applied:
+```swift
+public var drawer: AdvancedPageControlDraw = InfiniteScrollingDrawer() {
+    didSet {
+        (drawer as? AdvancedPageControlDrawerParent)?.alignment = alignment
+        setNeedsDisplay()
+    }
+}
+```
+
+---
+
+## Tests
+
+**DrawerParentAlignmentTests** (new file):
+- `.left`: first dot x == 0
+- `.right`: last dot x + dotSize == rect.width
+- `.center`: matches existing getCenteredXPosition output (no regression)
+- Switching alignment mid-session updates positions correctly
+
+**AdvancedPageControlViewAlignmentTests** (new file):
+- Setting `view.alignment` syncs to drawer
+- Assigning a new drawer inherits current alignment
+- All 13 drawers draw without crashing with `.left` and `.right`


### PR DESCRIPTION
## Summary
- Closes #15 — adds `.left`, `.center`, `.right` alignment to `AdvancedPageControlView`
- All 13 drawers inherit alignment automatically (no per-drawer changes needed)
- Default is `.center`, preserving existing behavior for all current users

## Usage
\`\`\`swift
pageControl.alignment = .left   // dots pinned to left edge
pageControl.alignment = .right  // dots pinned to right edge
pageControl.alignment = .center // default, centered (no change)
\`\`\`

## Test plan
- [x] 17 new tests: getCenteredXPosition for all 3 alignments, view sync, all 13 drawers draw without crash at .left and .right
- [x] 77 total tests, 0 failures, 0 regressions